### PR TITLE
Add order detail fetching functionality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { createPremiumInfoTool } from "./tools/premium-info.js";
 import { createDeliverySlotsTool } from "./tools/delivery-slots.js";
 import { createAnnouncementsTool } from "./tools/announcements.js";
 import { createReusableBagsTool } from "./tools/reusable-bags.js";
+import { createOrderDetailTool } from "./tools/order-detail.js";
 
 const server = new McpServer(
   {
@@ -55,6 +56,7 @@ const premiumInfo = createPremiumInfoTool(createRohlikAPI);
 const deliverySlots = createDeliverySlotsTool(createRohlikAPI);
 const announcements = createAnnouncementsTool(createRohlikAPI);
 const reusableBags = createReusableBagsTool(createRohlikAPI);
+const orderDetail = createOrderDetailTool(createRohlikAPI);
 
 // Core functionality
 server.registerTool(searchProducts.name, searchProducts.definition, searchProducts.handler);
@@ -66,6 +68,7 @@ server.registerTool(accountData.name, accountData.definition, accountData.handle
 
 // Order management
 server.registerTool(orderHistory.name, orderHistory.definition, orderHistory.handler);
+server.registerTool(orderDetail.name, orderDetail.definition, orderDetail.handler);
 server.registerTool(upcomingOrders.name, upcomingOrders.definition, upcomingOrders.handler);
 
 // Delivery management

--- a/src/rohlik-api.ts
+++ b/src/rohlik-api.ts
@@ -370,4 +370,15 @@ export class RohlikAPI {
       await this.logout();
     }
   }
+
+  async getOrderDetail(orderId: string): Promise<any> {
+    await this.login();
+
+    try {
+      const response = await this.makeRequest<any>(`/api/v3/orders/${orderId}`);
+      return response.data || response;
+    } finally {
+      await this.logout();
+    }
+  }
 }

--- a/src/tools/order-detail.ts
+++ b/src/tools/order-detail.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import { RohlikAPI } from "../rohlik-api.js";
+
+export function createOrderDetailTool(createRohlikAPI: () => RohlikAPI) {
+  return {
+    name: "get_order_detail",
+    definition: {
+      title: "Get Order Detail",
+      description: "Get detailed information about a specific order by its ID, including all products",
+      inputSchema: {
+        orderId: z.string().describe("The order ID to fetch details for")
+      }
+    },
+    handler: async (args: { orderId: string }) => {
+      const { orderId } = args;
+      
+      try {
+        const api = createRohlikAPI();
+        const orderDetail = await api.getOrderDetail(orderId);
+
+        if (!orderDetail) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Order with ID ${orderId} not found.`
+              }
+            ]
+          };
+        }
+
+        const formatProduct = (product: any, index: number): string => {
+          const name = product.productName || product.name || 'Unknown product';
+          const quantity = product.quantity || 1;
+          const price = product.price || product.totalPrice || 0;
+          const brand = product.brand || '';
+          
+          return `  ${index + 1}. ${name}${brand ? ` (${brand})` : ''}
+     Quantity: ${quantity}
+     Price: ${price} CZK`;
+        };
+
+        const order = orderDetail;
+        const orderNumber = order.orderNumber || order.id || orderId;
+        const orderDate = order.deliveredAt || order.createdAt || 'Unknown date';
+        const totalPrice = order.totalPrice || order.price || 'Unknown price';
+        const status = order.status || 'Unknown status';
+        const deliveryDate = order.deliveryDate || order.deliveredAt || 'Unknown delivery date';
+        const products = order.products || order.items || [];
+
+        const output = `📦 ORDER DETAILS - ${orderNumber}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Order Date: ${orderDate}
+Delivery Date: ${deliveryDate}
+Status: ${status}
+Total Price: ${totalPrice} CZK
+
+📋 PRODUCTS (${products.length} items):
+${products.map(formatProduct).join('\n\n')}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Total: ${totalPrice} CZK`;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: output
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: error instanceof Error ? error.message : String(error)
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,30 @@ export interface RohlikAPIResponse<T = any> {
   messages?: Array<{ content: string }>;
 }
 
+export interface OrderProduct {
+  id?: string;
+  productId?: string;
+  productName?: string;
+  name?: string;
+  quantity?: number;
+  price?: number;
+  totalPrice?: number;
+  brand?: string;
+}
+
+export interface OrderDetail {
+  id?: string;
+  orderNumber?: string;
+  status?: string;
+  createdAt?: string;
+  deliveredAt?: string;
+  deliveryDate?: string;
+  totalPrice?: number;
+  price?: number;
+  products?: OrderProduct[];
+  items?: OrderProduct[];
+}
+
 export interface AccountData {
   login?: any;
   delivery?: any;


### PR DESCRIPTION
Add new get_order_detail tool to fetch specific order information by ID, including complete product list and order details. Implements API endpoint /api/v3/orders/{orderId} with proper authentication and error handling.

This can be used to ask eg. for previously bought articles etc