### PR TITLE
Add detailed browser-like headers to API requests

### DIFF
--- a/src/rohlik-api.ts
+++ b/src/rohlik-api.ts
@@ -42,8 +42,18 @@ export class RohlikAPI {
     await this.rateLimit();
 
     const headers: Record<string, string> = {
+      'Accept': 'application/json, text/plain, */*',
+      'Accept-Language': 'cs-CZ,cs;q=0.9,en;q=0.8',
       'Content-Type': 'application/json',
-      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+      'Referer': BASE_URL,
+      'Origin': BASE_URL,
+      'sec-ch-ua': '"Google Chrome";v="119", "Chromium";v="119", "Not?A_Brand";v="24"',
+      'sec-ch-ua-mobile': '?0',
+      'sec-ch-ua-platform': '"macOS"',
+      'sec-fetch-dest': 'empty',
+      'sec-fetch-mode': 'cors',
+      'sec-fetch-site': 'same-origin',
       ...(this.sessionCookies && { Cookie: this.sessionCookies }),
       ...(options.headers as Record<string, string> || {})
     };


### PR DESCRIPTION
Closes: #7

This pull request updates the HTTP request headers used in the `RohlikAPI` class to better mimic a real browser session, which can help with compatibility and reduce the likelihood of requests being blocked or flagged as suspicious.

HTTP request header improvements:

* Added several browser-like headers (such as `Accept`, `Accept-Language`, `Referer`, `Origin`, and various `sec-` headers) to the `headers` object in the `RohlikAPI` class to more closely emulate requests from a real browser.
* Updated the `User-Agent` header to a more complete and realistic browser string.