### PR TITLE
feat: Add dynamic locale and currency based on region

### DIFF
--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,0 +1,31 @@
+const BASE_URL = process.env.ROHLIK_BASE_URL || 'https://www.rohlik.cz';
+
+const LOCALE_MAP: Record<string, string> = {
+  'rohlik.cz': 'cs-CZ,cs;q=0.9,en;q=0.8',
+  'knuspr.de': 'de-DE,de;q=0.9,en;q=0.8',
+  'gurkerl.at': 'de-AT,de;q=0.9,en;q=0.8',
+  'kifli.hu': 'hu-HU,hu;q=0.9,en;q=0.8',
+  'sezamo.ro': 'ro-RO,ro;q=0.9,en;q=0.8'
+};
+
+const CURRENCY_MAP: Record<string, string> = {
+  'rohlik.cz': 'CZK',
+  'knuspr.de': 'EUR',
+  'gurkerl.at': 'EUR',
+  'kifli.hu': 'HUF',
+  'sezamo.ro': 'RON'
+};
+
+function getDomain(): string | undefined {
+  return Object.keys(LOCALE_MAP).find(d => BASE_URL.includes(d));
+}
+
+export function getAcceptLanguage(): string {
+  const domain = getDomain();
+  return domain ? LOCALE_MAP[domain] : 'en;q=0.9';
+}
+
+export function getCurrency(): string {
+  const domain = getDomain();
+  return domain ? CURRENCY_MAP[domain] : 'CZK';
+}

--- a/src/rohlik-api.ts
+++ b/src/rohlik-api.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { Product, SearchResult, CartContent, RohlikCredentials, RohlikAPIResponse, AccountData } from './types.js';
+import { getAcceptLanguage } from './locale.js';
 
 const BASE_URL = process.env.ROHLIK_BASE_URL || 'https://www.rohlik.cz';
 
@@ -43,7 +44,7 @@ export class RohlikAPI {
 
     const headers: Record<string, string> = {
       'Accept': 'application/json, text/plain, */*',
-      'Accept-Language': 'cs-CZ,cs;q=0.9,en;q=0.8',
+      'Accept-Language': getAcceptLanguage(),
       'Content-Type': 'application/json',
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
       'Referer': BASE_URL,

--- a/src/tools/account-data.ts
+++ b/src/tools/account-data.ts
@@ -1,4 +1,5 @@
 import { RohlikAPI } from "../rohlik-api.js";
+import { getCurrency } from "../locale.js";
 
 export function createAccountDataTool(createRohlikAPI: () => RohlikAPI) {
   return {
@@ -29,7 +30,7 @@ export function createAccountDataTool(createRohlikAPI: () => RohlikAPI) {
         if (accountData.cart) {
           sections.push(`🛒 CART SUMMARY:
 • Total items: ${accountData.cart.total_items}
-• Total price: ${accountData.cart.total_price} CZK
+• Total price: ${accountData.cart.total_price} ${getCurrency()}
 • Can order: ${accountData.cart.can_make_order ? 'Yes' : 'No'}`);
         }
 

--- a/src/tools/cart-management.ts
+++ b/src/tools/cart-management.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { RohlikAPI } from "../rohlik-api.js";
+import { getCurrency } from "../locale.js";
 
 export function createCartManagementTools(createRohlikAPI: () => RohlikAPI) {
   return {
@@ -74,12 +75,12 @@ export function createCartManagementTools(createRohlikAPI: () => RohlikAPI) {
 
           const output = `Cart Summary:
 • Total items: ${cartContent.total_items}
-• Total price: ${cartContent.total_price} CZK
+• Total price: ${cartContent.total_price} ${getCurrency()}
 • Can order: ${cartContent.can_make_order ? 'Yes' : 'No'}
 
 Products in cart:
 ${cartContent.products.map(product => 
-  `• ${product.name} (${product.brand})\n  Quantity: ${product.quantity}\n  Price: ${product.price} CZK\n  Category: ${product.category_name}\n  Cart ID: ${product.cart_item_id}`
+  `• ${product.name} (${product.brand})\n  Quantity: ${product.quantity}\n  Price: ${product.price} ${getCurrency()}\n  Category: ${product.category_name}\n  Cart ID: ${product.cart_item_id}`
 ).join('\n\n')}`;
 
           return {

--- a/src/tools/delivery-info.ts
+++ b/src/tools/delivery-info.ts
@@ -1,4 +1,5 @@
 import { RohlikAPI } from "../rohlik-api.js";
+import { getCurrency } from "../locale.js";
 
 export function createDeliveryInfoTool(createRohlikAPI: () => RohlikAPI) {
   return {
@@ -34,11 +35,11 @@ export function createDeliveryInfoTool(createRohlikAPI: () => RohlikAPI) {
           }
 
           if (data.deliveryFee !== undefined) {
-            sections.push(`💰 DELIVERY FEE: ${data.deliveryFee} CZK`);
+            sections.push(`💰 DELIVERY FEE: ${data.deliveryFee} ${getCurrency()}`);
           }
 
           if (data.minimumOrder !== undefined) {
-            sections.push(`📦 MINIMUM ORDER: ${data.minimumOrder} CZK`);
+            sections.push(`📦 MINIMUM ORDER: ${data.minimumOrder} ${getCurrency()}`);
           }
 
           if (data.deliveryArea) {

--- a/src/tools/delivery-slots.ts
+++ b/src/tools/delivery-slots.ts
@@ -1,4 +1,5 @@
 import { RohlikAPI } from "../rohlik-api.js";
+import { getCurrency } from "../locale.js";
 
 export function createDeliverySlotsTool(createRohlikAPI: () => RohlikAPI) {
   return {
@@ -28,7 +29,7 @@ export function createDeliverySlotsTool(createRohlikAPI: () => RohlikAPI) {
           if (Array.isArray(data)) {
             return `⏰ AVAILABLE DELIVERY SLOTS:\n\n${data.map((slot, index) => 
               `${index + 1}. ${slot.date || 'Unknown date'} ${slot.time || slot.timeRange || 'Unknown time'}
-   Price: ${slot.price || slot.deliveryFee || 'Free'} CZK
+   Price: ${slot.price || slot.deliveryFee || 'Free'} ${getCurrency()}
    Available: ${slot.available ? 'Yes' : 'No'}`
             ).join('\n\n')}`;
           }

--- a/src/tools/order-detail.ts
+++ b/src/tools/order-detail.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { RohlikAPI } from "../rohlik-api.js";
+import { getCurrency } from "../locale.js";
 
 export function createOrderDetailTool(createRohlikAPI: () => RohlikAPI) {
   return {
@@ -37,7 +38,7 @@ export function createOrderDetailTool(createRohlikAPI: () => RohlikAPI) {
           
           return `  ${index + 1}. ${name}${brand ? ` (${brand})` : ''}
      Quantity: ${quantity}
-     Price: ${price} CZK`;
+     Price: ${price} ${getCurrency()}`;
         };
 
         const order = orderDetail;
@@ -53,13 +54,13 @@ export function createOrderDetailTool(createRohlikAPI: () => RohlikAPI) {
 Order Date: ${orderDate}
 Delivery Date: ${deliveryDate}
 Status: ${status}
-Total Price: ${totalPrice} CZK
+Total Price: ${totalPrice} ${getCurrency()}
 
 📋 PRODUCTS (${products.length} items):
 ${products.map(formatProduct).join('\n\n')}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Total: ${totalPrice} CZK`;
+Total: ${totalPrice} ${getCurrency()}`;
 
         return {
           content: [

--- a/src/tools/order-history.ts
+++ b/src/tools/order-history.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { RohlikAPI } from "../rohlik-api.js";
+import { getCurrency } from "../locale.js";
 
 export function createOrderHistoryTool(createRohlikAPI: () => RohlikAPI) {
   return {
@@ -37,7 +38,7 @@ export function createOrderHistoryTool(createRohlikAPI: () => RohlikAPI) {
           
           return `${index + 1}. ${orderNumber}
    Date: ${orderDate}
-   Total: ${totalPrice} CZK
+   Total: ${totalPrice} ${getCurrency()}
    Status: ${status}`;
         };
 

--- a/src/tools/premium-info.ts
+++ b/src/tools/premium-info.ts
@@ -1,4 +1,5 @@
 import { RohlikAPI } from "../rohlik-api.js";
+import { getCurrency } from "../locale.js";
 
 export function createPremiumInfoTool(createRohlikAPI: () => RohlikAPI) {
   return {
@@ -39,7 +40,7 @@ export function createPremiumInfoTool(createRohlikAPI: () => RohlikAPI) {
    Type: ${sub.type || 'Unknown'}
    Start: ${sub.startDate || 'Unknown'}
    End: ${sub.endDate || 'Unknown'}
-   Price: ${sub.price || 'Unknown'} CZK`);
+   Price: ${sub.price || 'Unknown'} ${getCurrency()}`);
           }
 
           // Benefits
@@ -50,11 +51,11 @@ ${data.benefits.map((benefit: any) => `   • ${benefit.name || benefit}`).join(
 
           // Savings
           if (data.totalSavings !== undefined) {
-            sections.push(`💰 TOTAL SAVINGS: ${data.totalSavings} CZK`);
+            sections.push(`💰 TOTAL SAVINGS: ${data.totalSavings} ${getCurrency()}`);
           }
 
           if (data.monthlySavings !== undefined) {
-            sections.push(`📊 MONTHLY SAVINGS: ${data.monthlySavings} CZK`);
+            sections.push(`📊 MONTHLY SAVINGS: ${data.monthlySavings} ${getCurrency()}`);
           }
 
           // Free delivery info

--- a/src/tools/upcoming-orders.ts
+++ b/src/tools/upcoming-orders.ts
@@ -1,4 +1,5 @@
 import { RohlikAPI } from "../rohlik-api.js";
+import { getCurrency } from "../locale.js";
 
 export function createUpcomingOrdersTool(createRohlikAPI: () => RohlikAPI) {
   return {
@@ -34,7 +35,7 @@ export function createUpcomingOrdersTool(createRohlikAPI: () => RohlikAPI) {
           
           return `${index + 1}. ${orderNumber}
    Delivery: ${deliveryDate} ${deliveryTime}
-   Total: ${totalPrice} CZK
+   Total: ${totalPrice} ${getCurrency()}
    Items: ${itemCount}
    Status: ${status}`;
         };


### PR DESCRIPTION
## Summary

- Adds `locale.ts` with centralized locale/currency mapping for all supported regions
- Sets `Accept-Language` header dynamically based on `ROHLIK_BASE_URL` domain
- Replaces hardcoded "CZK" with dynamic `getCurrency()` in all tool outputs

## Problem

When using non-Czech regions (e.g., kifli.hu for Hungary), the API was receiving `Accept-Language: cs-CZ` and all prices were displayed as "CZK" regardless of the actual region.

## Solution

Created a mapping from domain to locale/currency:

| Domain | Locale | Currency |
|--------|--------|----------|
| rohlik.cz | cs-CZ | CZK |
| knuspr.de | de-DE | EUR |
| gurkerl.at | de-AT | EUR |
| kifli.hu | hu-HU | HUF |
| sezamo.ro | ro-RO | RON |

## Files Changed

- `src/locale.ts` (new) - Centralized locale/currency utilities
- `src/rohlik-api.ts` - Uses `getAcceptLanguage()` for API requests
- `src/tools/*.ts` - All tools now use `getCurrency()` for price display

## Testing

Tested with `ROHLIK_BASE_URL=https://www.kifli.hu` - prices now correctly display in HUF.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)